### PR TITLE
Fixes Big Api Call Per Button Click

### DIFF
--- a/src/components/quote.js
+++ b/src/components/quote.js
@@ -5,21 +5,25 @@ class Quote extends Component {
     super(props);
 
     this.state = {
-      quote: "Ron Swanson",
+      quotes: [],
+      quote: "",
     };
   }
 
-  inRange(x, min, max) {
-    return (x - min) * (x - max) <= 0;
-  }
-
   getPortfolioItems = async () => {
-    const randomLine = Math.floor(Math.random() * 109);
     const quotesPromise = await fetch("http://localhost:5000/quotes");
     const quotes = await quotesPromise.json();
-    return (document.getElementById("quote").innerHTML =
-      quotes[Number(randomLine)]["line"]);
+    this.setState({ quotes });
   };
+
+  handleSingleQuote = () => {
+    const randomLine = Math.floor(Math.random() * this.state.quotes.length);
+    this.setState({quote: this.state.quotes[randomLine].line})
+  }
+
+  componentDidMount() {
+    this.getPortfolioItems()
+  }
 
   render() {
     return (
@@ -27,15 +31,15 @@ class Quote extends Component {
         <div className="button-wrapper">
           <button
             className="quote-button"
-            onClick={this.getPortfolioItems}
-            style={{ outline: "none;" }}
+            onClick={this.handleSingleQuote}
+            style={{ outline: "none" }}
           >
             GET A QUOTE
           </button>
         </div>
         <div className="quote-content">
           <h2>RON SWANSON SAYS:</h2>
-          <p id="quote"></p>
+          <p id="quote">{this.state.quote}</p>
         </div>
       </div>
     );


### PR DESCRIPTION
Changes proposed in this pull request:
- Currently every time the user clicks the get a quote, you need to `fetch` from the API
- I have modified it so the component will `fetch` all the quotes in `componentDidMount`
- I added a new method called `handleSingleQuote` that will randomly pick a quote from `this.state.quotes` and then set `this.state.quote` with that random quote
- Instead of targeting the dom element via id, I have the `p` tag value `this.state.quote`.  This will allow that `p` tag to always automatically have the newly generated quote.

Purposed Extra Steps:
- Don't let the user click the generate quote until all the quotes have been `fetched`
- Use some sort of `isLoading` state and show something else until all quotes have been `fetched`